### PR TITLE
Issue #4: Artist website URLs without http(s) are broken

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -74,3 +74,23 @@ export function formatDate(
   const date = new Date(isoString);
   return new Intl.DateTimeFormat(locales, options).format(date);
 }
+
+/**
+ * Given a URL, return a boolean value to indicate if it contains http(s)
+ * @param {string} url Could be an artist's web, facebook, instagram, etc. URL; should assume any of these links are incorrect
+ * @returns {boolean}
+ */
+export const containsProtocol = (url) => {
+  if(!url) return false
+
+  // The regex below tests if a url contains http(s), followed by ://, and subdomain/domain
+  let result = url.match(/(http(s?))/g);
+  return (result !== null)
+}
+
+/**
+ * Given a incorrectly formatted URL, prepend it with `http://` protocol so the at least the link works
+ * @param {string} url String to be prepended 
+ * @returns {string} Prepended `http://` protocol plus the original url 
+ */
+export const prependHttp = (url) => `http://${url}`

--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -4,7 +4,7 @@ import Layout from '@c/Layout'
 import FlexyRow from '@c/FlexyRow'
 import { Title } from '@c/Title'
 import { getShowBySlug } from '@l/graphcms'
-import { formatUSD, formatDate } from '@l/utils'
+import { formatUSD, formatDate, containsProtocol, prependHttp } from '@l/utils'
 
 const Markdown = styled(ReactMarkdown)`
   img {
@@ -58,7 +58,7 @@ export default function Shows({ show }) {
           <Portrait images={artist.images} />
 
           <FlexyRow justify="flex-start">
-            <a href={artist.webUrl} target="_blank">Website</a>
+            <a href={(containsProtocol(artist.webUrl)) ? artist.webUrl : prependHttp(artist.webUrl)} target="_blank">Website</a>
             <a href={artist.facebookUrl} target="_blank">Facebook</a>
             <a href={artist.instagramUrl} target="_blank">Instagram</a>
             <a href={artist.youTubeUrl} target="_blank">YouTube</a>


### PR DESCRIPTION
Link to issue: https://codevalapp.github.io/next-graphcms-shows/issues/4/

Some artists have uploaded their website url without a http(s) protocol, which throws an error when clicking on the link. 

In lib/util.js, there are two new functions to address this issue:

containsProtocol() tests if a url has a protocol
prependHttp() simply prepends http:// to a url if it's nonexistent 

In pages/show/[slug].js, the <a> tag's href attribute will use the above functions. The artist's webUrl is first checked if it contains a protocol. If so, then no further work needs to be done. Otherwise, `http://` will be added to the webUrl so it works correctly. 