### PR TITLE
Issue #5: Conditionally show artist URLs

### DIFF
--- a/components/Link/index.js
+++ b/components/Link/index.js
@@ -1,0 +1,6 @@
+import { containsProtocol, prependHttp } from '@l/utils'
+
+export const Link = ({url, title}) => {
+  return <a href={(containsProtocol(url)) ? url : prependHttp(url)} target="_blank"> {title} </a>
+};
+

--- a/components/Link/index.js
+++ b/components/Link/index.js
@@ -1,6 +1,9 @@
-import { containsProtocol, prependHttp } from '@l/utils'
+import { containsProtocol, prependHttps } from '@l/utils'
 
-export const Link = ({url, title}) => {
-  return <a href={(containsProtocol(url)) ? url : prependHttp(url)} target="_blank"> {title} </a>
-};
+export const Link = ({url, title}) => 
+  url && (
+    <a href={(containsProtocol(url)) ? url : prependHttps(url)} target="_blank"> 
+      {title} 
+    </a>
+  )
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -89,8 +89,8 @@ export const containsProtocol = (url) => {
 }
 
 /**
- * Given a incorrectly formatted URL, prepend it with `http://` protocol so the at least the link works
+ * Given a incorrectly formatted URL, prepend it with `https://` protocol so the at least the link works
  * @param {string} url String to be prepended 
- * @returns {string} Prepended `http://` protocol plus the original url 
+ * @returns {string} Prepended `https://` protocol plus the original url 
  */
-export const prependHttp = (url) => `http://${url}`
+export const prependHttps = (url) => `https://${url}`

--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -1,10 +1,11 @@
 import ReactMarkdown from 'react-markdown'
 import styled from 'styled-components'
 import Layout from '@c/Layout'
+import { Link } from "@c/Link"
 import FlexyRow from '@c/FlexyRow'
 import { Title } from '@c/Title'
 import { getShowBySlug } from '@l/graphcms'
-import { formatUSD, formatDate, containsProtocol, prependHttp } from '@l/utils'
+import { formatUSD, formatDate } from '@l/utils'
 
 const Markdown = styled(ReactMarkdown)`
   img {
@@ -58,10 +59,10 @@ export default function Shows({ show }) {
           <Portrait images={artist.images} />
 
           <FlexyRow justify="flex-start">
-            <a href={(containsProtocol(artist.webUrl)) ? artist.webUrl : prependHttp(artist.webUrl)} target="_blank">Website</a>
-            <a href={artist.facebookUrl} target="_blank">Facebook</a>
-            <a href={artist.instagramUrl} target="_blank">Instagram</a>
-            <a href={artist.youTubeUrl} target="_blank">YouTube</a>
+            <Link url={artist.webUrl} title={"Website"} />
+            <Link url={artist.facebookUrl} title={"Facebook"} />
+            <Link url={artist.instagramUrl} title={"Instagram"} />
+            <Link url={artist.youTubeUrl} title={"YouTube"} />
           </FlexyRow>
 
           <Markdown source={artist.bio} />


### PR DESCRIPTION
Originally artist URLs were rendered even if the url was null. 

<a> tags have been refactored into its own component, <Link /> in components/Link, which contains the logic for both determining if a url contains a http(s) protocol and conditionally rendering the url only if it exists.