### PR TITLE
Issue #3: Add ability to sort shows

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -8,17 +8,35 @@ individual routes can be directed to respectively.
 
 Going down the list of issues, I really like the Create show list view feature. Keep this one on the backburner for now though as I'd like to familiarize myself with the innerworkings of this app first.
 
+Issue #4 and #5 are more warmup bug fixes to get started with.. 
+
 Priority 1: 
 
-These two are more warmups issues to get started with.. 
-
 For artist website URLs if a url does not have a protocol this can be checked and then appended to the string so it operates correctly 
-- Artist website URLs without http(s) are broken 
+
+- Issue #4: Artist website URLs without http(s) are broken ✅
+
 
 For conditionally showing artist URLs.. well, if the field is not null, then load it. 
-- Conditionally show artist URLs
+
+(Update) After completing the broken artist website URL issue, I'm thinking I can refactor <a> tags to be its own component. I don't want to repeat the logic with containsProtocol()/prependHttp(), and if I'm checking if a URL is null this can be made universal in a single component. 
+
+- Issue #5: Conditionally show artist URLs ✅
+
+
+Sorting is a tricky one, and the solution for this issue depends. For the data set I am currently given, it is much faster to sort the data on the client side. However, if we were dealing with 1000's of rows to sort, then sorting would be more efficient on the client side. 
+
+Sorting with GraphQL is not realistic here because these queries are executed at build time, therefore you cannot change GraphQL queries in the client. 
+
+- Issue #3: Add ability to sort shows 
+
+
+- Issue #1: Create show list (not grid) view 
+- Issue #2: Page /404 for `shows`
 
 Priority 2: 
 
-- Create show list view 
-- Page /404 for `shows`
+- Issue #8: Shows uniform display on mobile 
+- Issue #9: Shows page is stupid-wide, not centered 
+- Issue #6: Add `spotifyUrl` to list of Artist links 
+- Issue #7: Add Artist Route 

--- a/components/Sort/Sort.css.js
+++ b/components/Sort/Sort.css.js
@@ -1,0 +1,54 @@
+import styled from 'styled-components'
+
+export const Wrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`
+
+export const StyledButton = styled.button`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  flex-wrap: none;
+  background: transparent;
+  border: 1px solid white;
+  border-radius: 5px;
+  color: white;
+  padding: 0.5rem;
+  margin: 1rem;
+
+  :hover {
+    color: #000;
+    background-color: var(--gallery-grey);
+  }
+`
+
+export const StyledUl = styled.ul`
+  position: absolute;
+  top: 150%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  list-style-type: none;
+  background: white;
+  box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px, rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
+  border: 1px solid white;
+  border-radius: 5px;
+  color: black;
+  padding: 0;
+`
+
+export const StyledOption = styled.div`
+  cursor: pointer;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+
+  :hover,
+  :focus,
+  :active {
+    color: #000;
+    background-color: var(--gallery-grey);
+  }
+`

--- a/components/Sort/index.js
+++ b/components/Sort/index.js
@@ -1,4 +1,4 @@
-import { useState, useContext } from 'react'
+import React, { useState, useContext } from 'react'
 import styled, { css } from 'styled-components'
 import { FaAngleDown, FaSortAmountDown, FaSortAmountUp } from 'react-icons/fa'
 //import { applySort } from '@l/utils'
@@ -43,6 +43,11 @@ function Button({ type, icon, property }) {
   )
 }
 
+/**
+ * @param {string} title The title of the property we'd like to sort shows on 
+ * @param {array} options An array of objects which contains meta data for sorting (by title/scheduledStartTime, ascending/descending, icon, etc.)
+ * @returns {ReactFragment}
+*/
 export function Sort({ title, options }) {
   const [toggle, setToggle] = useState(false)
 

--- a/components/Sort/index.js
+++ b/components/Sort/index.js
@@ -1,26 +1,29 @@
 import React, { useState, useContext } from 'react'
-import styled, { css } from 'styled-components'
 import { FaAngleDown, FaSortAmountDown, FaSortAmountUp } from 'react-icons/fa'
-//import { applySort } from '@l/utils'
 import { ShowsContext } from '../../pages/shows'
 import { sortByProperty } from '@l/utils'
+import { Wrapper, StyledButton, StyledUl, StyledOption } from './Sort.css'
 
-const StyledButton = styled.button`
-  display: flex;
-  align-items: center;
-  flex-direction: row;
-  flex-wrap: none;
-`
-
-const StyledUl = styled.ul`
- list-style-type: none;
- background: white;
- box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px, rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
- color: black;
- padding: 1rem;
-`
-
-function Button({ type, icon, property }) {
+/**
+ * Why perform sorting on the client side? 
+ * 
+ * Sorting is a tricky one, and the solution for this issue depends entirely on the size of the data set givem, 
+ * and what constraints may need to be applied to this data set. 
+ * 
+ * If we were dealing with 1000's of objects to sort through, then sorting would be more efficient on the server side. 
+ * We could also implement pagination to break down the problem of sorting 1000's of objects into smaller subsets to sort. 
+ * 
+ * I thought about approaching issue #3 with GraphQL, using some sort of dynamic query where I could pass in the property
+ * to be sorted on, plus ascending/descending order. However, sorting with GraphQL is not realistic in this case because these 
+ * queries are executed at build time, therefore you cannot change GraphQL queries from the client. The only other option 
+ * would be to write a new query for both ascending/descending, then pass in the property you want to sort on, but I disagree
+ * with this approach due to scaling issues.  
+ * 
+ * Ultimately I decided that for an array of objects, containing show metadata, it is much faster to sort the data on the client side due
+ * to the array's small size. If this were a real application with larger data set, I would definitely think about adding pagination to 
+ * reduce the overall size of the array of objects. 
+ */
+function SortOption({ type, icon, property }) {
   const [data, setData] = useContext(ShowsContext)
 
   const applySort = (property) => {
@@ -36,10 +39,10 @@ function Button({ type, icon, property }) {
   }
 
   return (
-    <StyledButton onClick={() => applySort(property)}> 
+    <StyledOption onClick={() => applySort(property)}> 
+      <span> { icon } </span>
       <span> { type } </span>
-      { icon }
-    </StyledButton>
+    </StyledOption>
   )
 }
 
@@ -52,7 +55,7 @@ export function Sort({ title, options }) {
   const [toggle, setToggle] = useState(false)
 
   return (
-    <>
+    <Wrapper>
       <StyledButton onClick={() => setToggle(!toggle)}> 
         <span> { title } </span>
         <FaAngleDown />
@@ -62,7 +65,7 @@ export function Sort({ title, options }) {
         <StyledUl>
           {options.map(option => (
             <li key={option.id}>
-              <Button 
+              <SortOption 
                 property={option.property}
                 type={option.type}
                 icon={option.icon}
@@ -71,6 +74,6 @@ export function Sort({ title, options }) {
           ))}
         </StyledUl>
       )}
-    </>
+    </Wrapper>
   )
 }

--- a/components/Sort/index.js
+++ b/components/Sort/index.js
@@ -1,0 +1,77 @@
+import { useState, useContext } from 'react'
+import styled, { css } from 'styled-components'
+import { FaAngleDown, FaSortAmountDown, FaSortAmountUp } from 'react-icons/fa'
+//import { applySort } from '@l/utils'
+import { ShowsContext } from '../../pages/shows'
+import { sortByProperty } from '@l/utils'
+
+const StyledButton = styled.button`
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  flex-wrap: none;
+`
+
+const StyledUl = styled.ul`
+ list-style-type: none;
+ background: white;
+ box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px, rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
+ color: black;
+ padding: 1rem;
+`
+
+function Button({ type, icon, property }) {
+  const [data, setData] = useContext(ShowsContext)
+
+  const applySort = (property) => {
+    /**
+     * Arrays in JS are referenced types, so even though sorting takes place it doesn't 
+     * change the reference to the original array. 
+     * 
+     * Solution here is to use spread operator inside new Array.
+     */
+    setData([
+      ...data.sort(sortByProperty(property))
+    ])
+  }
+
+  return (
+    <StyledButton onClick={() => applySort(property)}> 
+      <span> { type } </span>
+      { icon }
+    </StyledButton>
+  )
+}
+
+export function Sort({ title, options }) {
+  const [toggle, setToggle] = useState(false)
+
+  return (
+    <>
+      <StyledButton onClick={() => setToggle(!toggle)}> 
+        <span> { title } </span>
+        <FaAngleDown />
+      </StyledButton>
+
+      {toggle && (
+        <StyledUl>
+          <li> 
+            <Button 
+              type={"Ascending"} 
+              icon={<FaSortAmountUp />} 
+              property={"title"}
+            />
+          </li>
+          <li> 
+            <Button 
+              type={"Descending"} 
+              icon={<FaSortAmountDown />} 
+              property={"-title"}
+            /> 
+          </li> 
+          
+        </StyledUl>
+      )}
+    </>
+  )
+}

--- a/components/Sort/index.js
+++ b/components/Sort/index.js
@@ -55,21 +55,15 @@ export function Sort({ title, options }) {
 
       {toggle && (
         <StyledUl>
-          <li> 
-            <Button 
-              type={"Ascending"} 
-              icon={<FaSortAmountUp />} 
-              property={"title"}
-            />
-          </li>
-          <li> 
-            <Button 
-              type={"Descending"} 
-              icon={<FaSortAmountDown />} 
-              property={"-title"}
-            /> 
-          </li> 
-          
+          {options.map(option => (
+            <li key={option.id}>
+              <Button 
+                property={option.property}
+                type={option.type}
+                icon={option.icon}
+              />
+            </li>
+          ))}
         </StyledUl>
       )}
     </>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "raw-loader": "^4.0.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-icons": "^4.4.0",
     "react-markdown": "^5.0.3",
     "styled-components": "^5.2.3"
   },

--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -1,7 +1,7 @@
 import ReactMarkdown from 'react-markdown'
 import styled from 'styled-components'
 import Layout from '@c/Layout'
-import { Link } from "@c/Link"
+import { Link } from '@c/Link'
 import FlexyRow from '@c/FlexyRow'
 import { Title } from '@c/Title'
 import { getShowBySlug } from '@l/graphcms'

--- a/pages/shows.js
+++ b/pages/shows.js
@@ -18,26 +18,45 @@ export default function Shows({ data }) {
     <Layout title="next-graphcms-shows / Shows">
       <Title>Shows</Title>
 
+      {
+        /**
+         * To avoid prop drilling, pass [shows, setShows] into our Sort components with a context provider
+         */
+      }
       <ShowsContext.Provider value={[shows, setShows]}>
         <Sort 
           title={"Title"} 
           options={[
             {
               id: 0,
-              type: "Ascending",
               property: "title",
+              type: "Ascending",
               icon: <FaSortAmountUp />
             },
             {
               id: 1,
-              type: "Descending",
               property: "-title",
+              type: "Descending",
               icon: <FaSortAmountDown />
             }
           ]} 
         />
         <Sort 
           title={"Scheduled Start Time"} 
+          options={[
+            {
+              id: 0,
+              property: "scheduledStartTime",
+              type: "Ascending",
+              icon: <FaSortAmountUp />
+            },
+            {
+              id: 1,
+              property: "-scheduledStartTime",
+              type: "Descending",
+              icon: <FaSortAmountDown />
+            }
+          ]} 
         />
       </ShowsContext.Provider>
 

--- a/pages/shows.js
+++ b/pages/shows.js
@@ -1,12 +1,35 @@
+import { useEffect, useState } from "react";
 import Layout from '@c/Layout'
 import { Grid, Card } from '@c/Grid'
 import { Title } from '@c/Title'
 import { getAllShows } from '@l/graphcms'
+import { sortByProperty } from '@l/utils'
 
-export default function Shows({ shows }) {
+export default function Shows({ data }) {
+  const [shows, setShows] = useState([]);
+
+  useEffect(() => setShows(data), [])
+
+  const sortShows = (property) => {
+    /**
+     * Arrays in JS are referenced types, so even though sorting takes place it doesn't 
+     * change the reference to the original array. 
+     * 
+     * Solution here is to use spread operator inside new Array.
+     */
+    setShows([...shows.sort(sortByProperty(property))])
+  }
+
   return (
     <Layout title="next-graphcms-shows / Shows">
       <Title>Shows</Title>
+
+      <button onClick={() => sortShows("title")}> Sort by title ascending </button>
+      <button onClick={() => sortShows("-title")}> Sort by title descending </button>
+
+      <button onClick={() => sortShows("scheduledStartTime")}> Sort by scheduledStartTime ascending </button>
+      <button onClick={() => sortShows("-scheduledStartTime")}> Sort by scheduledStartTime descending </button>
+
       <Grid>
         {shows.map(show => (
           <Card href={`/show/${show.slug}`} header={show.title} key={show.id}>
@@ -19,8 +42,8 @@ export default function Shows({ shows }) {
 }
 
 export async function getServerSideProps() {
-  const shows = (await getAllShows()) || []
+  const data = (await getAllShows()) || []
   return {
-    props: { shows },
+    props: { data },
   }
 }

--- a/pages/shows.js
+++ b/pages/shows.js
@@ -1,4 +1,5 @@
 import { useEffect, useState, createContext } from "react";
+import { FaSortAmountDown, FaSortAmountUp } from 'react-icons/fa'
 import Layout from '@c/Layout'
 import { Grid, Card } from '@c/Grid'
 import { Title } from '@c/Title'
@@ -24,16 +25,20 @@ export default function Shows({ data }) {
             {
               id: 0,
               type: "Ascending",
-              property: "title"
+              property: "title",
+              icon: <FaSortAmountUp />
             },
             {
               id: 1,
               type: "Descending",
-              property: "-title"
+              property: "-title",
+              icon: <FaSortAmountDown />
             }
           ]} 
         />
-        <Sort title={"Scheduled Start Time"} />
+        <Sort 
+          title={"Scheduled Start Time"} 
+        />
       </ShowsContext.Provider>
 
       <Grid>

--- a/pages/shows.js
+++ b/pages/shows.js
@@ -1,11 +1,19 @@
-import { useEffect, useState, createContext } from "react";
+import { useEffect, useState, createContext } from 'react';
+import styled, { css } from 'styled-components'
 import { FaSortAmountDown, FaSortAmountUp } from 'react-icons/fa'
 import Layout from '@c/Layout'
 import { Grid, Card } from '@c/Grid'
 import { Title } from '@c/Title'
 import { Sort } from '@c/Sort'
 import { getAllShows } from '@l/graphcms'
-import { sortByProperty } from '@l/utils'
+
+const StyledWrapper = css`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  margin: 1rem 0rem 4rem 0rem;
+`
 
 export const ShowsContext = createContext([{}, () => {}])
 
@@ -21,43 +29,47 @@ export default function Shows({ data }) {
       {
         /**
          * To avoid prop drilling, pass [shows, setShows] into our Sort components with a context provider
+         * 
+         * Issue #3: reasoning for sorting in client-side explained in <Sort /> component 
          */
       }
       <ShowsContext.Provider value={[shows, setShows]}>
-        <Sort 
-          title={"Title"} 
-          options={[
-            {
-              id: 0,
-              property: "title",
-              type: "Ascending",
-              icon: <FaSortAmountUp />
-            },
-            {
-              id: 1,
-              property: "-title",
-              type: "Descending",
-              icon: <FaSortAmountDown />
-            }
-          ]} 
-        />
-        <Sort 
-          title={"Scheduled Start Time"} 
-          options={[
-            {
-              id: 0,
-              property: "scheduledStartTime",
-              type: "Ascending",
-              icon: <FaSortAmountUp />
-            },
-            {
-              id: 1,
-              property: "-scheduledStartTime",
-              type: "Descending",
-              icon: <FaSortAmountDown />
-            }
-          ]} 
-        />
+        <div css={StyledWrapper}>
+          <Sort 
+            title={"Title"} 
+            options={[
+              {
+                id: 0,
+                property: "title",
+                type: "Ascending",
+                icon: <FaSortAmountUp />
+              },
+              {
+                id: 1,
+                property: "-title",
+                type: "Descending",
+                icon: <FaSortAmountDown />
+              }
+            ]} 
+          />
+          <Sort 
+            title={"Scheduled Start Time"} 
+            options={[
+              {
+                id: 0,
+                property: "scheduledStartTime",
+                type: "Ascending",
+                icon: <FaSortAmountUp />
+              },
+              {
+                id: 1,
+                property: "-scheduledStartTime",
+                type: "Descending",
+                icon: <FaSortAmountDown />
+              }
+            ]} 
+          />
+        </div>
       </ShowsContext.Provider>
 
       <Grid>

--- a/pages/shows.js
+++ b/pages/shows.js
@@ -1,34 +1,40 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, createContext } from "react";
 import Layout from '@c/Layout'
 import { Grid, Card } from '@c/Grid'
 import { Title } from '@c/Title'
+import { Sort } from '@c/Sort'
 import { getAllShows } from '@l/graphcms'
 import { sortByProperty } from '@l/utils'
+
+export const ShowsContext = createContext([{}, () => {}])
 
 export default function Shows({ data }) {
   const [shows, setShows] = useState([]);
 
   useEffect(() => setShows(data), [])
 
-  const sortShows = (property) => {
-    /**
-     * Arrays in JS are referenced types, so even though sorting takes place it doesn't 
-     * change the reference to the original array. 
-     * 
-     * Solution here is to use spread operator inside new Array.
-     */
-    setShows([...shows.sort(sortByProperty(property))])
-  }
-
   return (
     <Layout title="next-graphcms-shows / Shows">
       <Title>Shows</Title>
 
-      <button onClick={() => sortShows("title")}> Sort by title ascending </button>
-      <button onClick={() => sortShows("-title")}> Sort by title descending </button>
-
-      <button onClick={() => sortShows("scheduledStartTime")}> Sort by scheduledStartTime ascending </button>
-      <button onClick={() => sortShows("-scheduledStartTime")}> Sort by scheduledStartTime descending </button>
+      <ShowsContext.Provider value={[shows, setShows]}>
+        <Sort 
+          title={"Title"} 
+          options={[
+            {
+              id: 0,
+              type: "Ascending",
+              property: "title"
+            },
+            {
+              id: 1,
+              type: "Descending",
+              property: "-title"
+            }
+          ]} 
+        />
+        <Sort title={"Scheduled Start Time"} />
+      </ShowsContext.Provider>
 
       <Grid>
         {shows.map(show => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1860,6 +1860,11 @@ react-dom@17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-icons@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.4.0.tgz#a13a8a20c254854e1ec9aecef28a95cdf24ef703"
+  integrity sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==
+
 react-is@16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
New feature: add functionality for sorting shows by title (ascending and descending) and scheduledStartTime (ascending and descending).

I created a Sort component, located in components/Sort, which takes two properties: the title of the button (ie. title, scheduledStartTime) and options such as the property to be sorted on, sorting type (ascending/descending) and an icon. 

A context provider is used so that the [shows, setShows] react hook in shows.js is rerendered once sorting is complete within <Sort />. This step was also taken in order to avoid prop drilling. 

I chose to sort data on the client side- reasoning is included in components/Sort/index.js.  