### PR TITLE
Issue #1: Create show list (not grid) view

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -24,7 +24,7 @@ For conditionally showing artist URLs.. well, if the field is not null, then loa
 - Issue #5: Conditionally show artist URLs ✅
 
 
-Sorting is a tricky one, and the solution for this issue depends. For the data set I am currently given, it is much faster to sort the data on the client side. However, if we were dealing with 1000's of rows to sort, then sorting would be more efficient on the client side. 
+Sorting is a tricky one, and the solution for this issue depends. For the data set I am currently given, it is much faster to sort the data on the client side. However, if we were dealing with 1000's of rows to sort, then sorting would be more efficient on the server side. 
 
 Sorting with GraphQL is not realistic here because these queries are executed at build time, therefore you cannot change GraphQL queries in the client. 
 

--- a/components/List/List.css.js
+++ b/components/List/List.css.js
@@ -1,0 +1,52 @@
+import styled, { css } from 'styled-components'
+
+export const StyledList = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: none;
+  margin-top: 1rem;
+  width: 90%;
+  background: white;
+  border: 1px solid black;
+  border-radius: 5px;
+  margin: 1rem;
+`
+
+export const TotalShows = css`
+  color: black;
+`
+
+export const ListContent = css`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: none;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 2rem;
+  width: 100%;
+  border-top: 1px solid black;
+  color: black;
+`
+
+export const ContentHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: none;
+  justify-content: center;
+  align-items: center;
+`
+
+export const ContentDescription = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: none;
+  justify-content: center;
+  align-items: center;
+  margin-left: auto;
+
+  span {
+    padding: 0.5rem;
+  }
+`

--- a/components/List/index.js
+++ b/components/List/index.js
@@ -1,60 +1,9 @@
 import Link from 'next/link'
-import styled, { css } from 'styled-components'
 import { formatDate } from '@l/utils'
-
-const StyledList = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  flex-wrap: none;
-  margin-top: 1rem;
-  width: 90%;
-  background: white;
-  border: 1px solid black;
-  border-radius: 5px;
-  margin: 5rem;
-`
-
-const TotalShows = css`
-  color: black;
-`
-
-const ListContent = css`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: none;
-  justify-content: flex-start;
-  align-items: center;
-  padding: 2rem;
-  width: 100%;
-  border-top: 1px solid black;
-  color: black;
-`
-
-const ContentHeader = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex-wrap: none;
-  justify-content: center;
-  align-items: center;
-`
-
-const ContentDescription = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex-wrap: none;
-  justify-content: center;
-  align-items: center;
-  margin-left: auto;
-
-  span {
-    padding: 0.5rem;
-  }
-`
+import { StyledList, TotalShows, ListContent, ContentHeader, ContentDescription } from './List.css'
 
 function Content({ href, show }) {
-  return href ? (
+  return href && (
     <Link href={href}>
       <a css={ListContent}>
         <ContentHeader>
@@ -67,17 +16,6 @@ function Content({ href, show }) {
         </ContentDescription>
       </a>
     </Link>
-  ) : (
-    <div>
-      <ContentHeader>
-        <h2> { show.title } </h2>
-        <h4> {show.artists.map(({ fullName }) => fullName).join(', ')} </h4>
-      </ContentHeader>
-      <ContentDescription>
-        <span> { formatDate(show.scheduledStartTime) } </span>
-        <span> $ { show.ticketPrice } </span>
-      </ContentDescription>
-    </div>
   )
 }
 
@@ -97,28 +35,3 @@ export function List({ shows }) {
     </StyledList>
   )
 }
-
-/**
- * <thead>
-        <tr>
-          <th> Name </th>
-          <th> Artists </th>
-          <th> Scheduled Start Time </th>
-          <th> Ticket Price </th>
-        </tr>
-      </thead>
-      <tbody>
-        {shows.map(show => {
-          if(show.title) {
-            return (
-              <tr key={show.id}>
-                <td> { show.title } </td>
-                <td> {show.artists.map(({ fullName }) => fullName).join(', ')} </td>
-                <td> { formatDate(show.scheduledStartTime) } </td>
-                <td> $ { show.ticketPrice } </td>
-              </tr>
-            )
-          }
-        })}
-      </tbody>
- */

--- a/components/List/index.js
+++ b/components/List/index.js
@@ -1,0 +1,124 @@
+import Link from 'next/link'
+import styled, { css } from 'styled-components'
+import { formatDate } from '@l/utils'
+
+const StyledList = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: none;
+  margin-top: 1rem;
+  width: 90%;
+  background: white;
+  border: 1px solid black;
+  border-radius: 5px;
+  margin: 5rem;
+`
+
+const TotalShows = css`
+  color: black;
+`
+
+const ListContent = css`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: none;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 2rem;
+  width: 100%;
+  border-top: 1px solid black;
+  color: black;
+`
+
+const ContentHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: none;
+  justify-content: center;
+  align-items: center;
+`
+
+const ContentDescription = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: none;
+  justify-content: center;
+  align-items: center;
+  margin-left: auto;
+
+  span {
+    padding: 0.5rem;
+  }
+`
+
+function Content({ href, show }) {
+  return href ? (
+    <Link href={href}>
+      <a css={ListContent}>
+        <ContentHeader>
+          <h2> { show.title } </h2>
+          <h4> {show.artists.map(({ fullName }) => fullName).join(', ')} </h4>
+        </ContentHeader>
+        <ContentDescription>
+          <span> { formatDate(show.scheduledStartTime) } </span>
+          <span> $ { show.ticketPrice } </span>
+        </ContentDescription>
+      </a>
+    </Link>
+  ) : (
+    <div>
+      <ContentHeader>
+        <h2> { show.title } </h2>
+        <h4> {show.artists.map(({ fullName }) => fullName).join(', ')} </h4>
+      </ContentHeader>
+      <ContentDescription>
+        <span> { formatDate(show.scheduledStartTime) } </span>
+        <span> $ { show.ticketPrice } </span>
+      </ContentDescription>
+    </div>
+  )
+}
+
+export function List({ shows }) {
+  return (
+    <StyledList>
+      <div css={TotalShows}>
+        <p> <b> {shows.length} </b> shows in all locations </p>
+      </div>
+      {shows.map(show => {
+        if(show.title) {
+          return (
+            <Content href={`/show/${show.slug}`} show={show} key={show.id} />
+          )
+        }
+      })}
+    </StyledList>
+  )
+}
+
+/**
+ * <thead>
+        <tr>
+          <th> Name </th>
+          <th> Artists </th>
+          <th> Scheduled Start Time </th>
+          <th> Ticket Price </th>
+        </tr>
+      </thead>
+      <tbody>
+        {shows.map(show => {
+          if(show.title) {
+            return (
+              <tr key={show.id}>
+                <td> { show.title } </td>
+                <td> {show.artists.map(({ fullName }) => fullName).join(', ')} </td>
+                <td> { formatDate(show.scheduledStartTime) } </td>
+                <td> $ { show.ticketPrice } </td>
+              </tr>
+            )
+          }
+        })}
+      </tbody>
+ */

--- a/components/ToggleView/index.js
+++ b/components/ToggleView/index.js
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import styled, { css } from 'styled-components'
+import { BsFillGrid3X3GapFill, BsCardChecklist } from 'react-icons/bs'
+
+const Toggle = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: none;
+  justify-content: center;
+  align-items: center;
+`
+
+const StyledButton = styled.div`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  flex-wrap: none;
+  background: transparent;
+  border: 1px solid white;
+  border-radius: 5px;
+  color: white;
+  padding: 0.5rem;
+  margin: 1rem;
+
+  :hover {
+    color: #000;
+    background-color: var(--gallery-grey);
+  }
+`
+
+export function ToggleView({ grid, setGrid }) {
+  return (
+    <>
+      <p> Toggle view </p>
+      <Toggle>
+        <StyledButton onClick={() => { if(!grid) setGrid(!grid) }}> 
+          <span> Grid </span> 
+          <BsFillGrid3X3GapFill /> 
+        </StyledButton>
+
+        <StyledButton onClick={() => { if(grid) setGrid(!grid) }}> 
+          <span> List </span> 
+          <BsCardChecklist /> 
+        </StyledButton>
+      </Toggle>
+    </>
+  )
+}

--- a/lib/graphcms.js
+++ b/lib/graphcms.js
@@ -36,6 +36,7 @@ export async function getAllShows() {
           fullName
           slug
         }
+        ticketPrice
       }
     }`
   )

--- a/pages/shows.js
+++ b/pages/shows.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, createContext } from 'react';
+import { useEffect, useState, createContext } from 'react'
 import styled, { css } from 'styled-components'
 import { FaSortAmountDown, FaSortAmountUp } from 'react-icons/fa'
 import Layout from '@c/Layout'
@@ -6,6 +6,7 @@ import { Grid, Card } from '@c/Grid'
 import { List } from '@c/List'
 import { Title } from '@c/Title'
 import { Sort } from '@c/Sort'
+import { ToggleView } from '@c/ToggleView'
 import { getAllShows } from '@l/graphcms'
 
 const StyledWrapper = css`
@@ -19,15 +20,18 @@ const StyledWrapper = css`
 export const ShowsContext = createContext([{}, () => {}])
 
 export default function Shows({ data }) {
-  console.log(data);
   const [shows, setShows] = useState([]);
+  const [grid, setGrid] = useState(true)
 
   useEffect(() => setShows(data), [])
 
   return (
     <Layout title="next-graphcms-shows / Shows">
       <Title>Shows</Title>
-
+      <ToggleView 
+        grid={grid}
+        setGrid={setGrid}
+      />
       {
         /**
          * To avoid prop drilling, pass [shows, setShows] into our Sort components with a context provider
@@ -73,15 +77,18 @@ export default function Shows({ data }) {
           />
         </div>
       </ShowsContext.Provider>
-
-      <Grid>
-        {shows.map(show => (
-          <Card href={`/show/${show.slug}`} header={show.title} key={show.id}>
-            <p>{show.artists.map(({ fullName }) => fullName).join(', ')}</p>
-          </Card>
-        ))}
-      </Grid>
-      <List shows={shows} />
+      
+      {grid ? (
+        <Grid>
+          {shows.map(show => (
+            <Card href={`/show/${show.slug}`} header={show.title} key={show.id}>
+              <p>{show.artists.map(({ fullName }) => fullName).join(', ')}</p>
+            </Card>
+          ))}
+        </Grid>
+      ) : (
+        <List shows={shows} />
+      )}
     </Layout>
   )
 }

--- a/pages/shows.js
+++ b/pages/shows.js
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components'
 import { FaSortAmountDown, FaSortAmountUp } from 'react-icons/fa'
 import Layout from '@c/Layout'
 import { Grid, Card } from '@c/Grid'
+import { List } from '@c/List'
 import { Title } from '@c/Title'
 import { Sort } from '@c/Sort'
 import { getAllShows } from '@l/graphcms'
@@ -18,6 +19,7 @@ const StyledWrapper = css`
 export const ShowsContext = createContext([{}, () => {}])
 
 export default function Shows({ data }) {
+  console.log(data);
   const [shows, setShows] = useState([]);
 
   useEffect(() => setShows(data), [])
@@ -79,6 +81,7 @@ export default function Shows({ data }) {
           </Card>
         ))}
       </Grid>
+      <List shows={shows} />
     </Layout>
   )
 }


### PR DESCRIPTION
Originally, the user was only able to look at shows from a grid view. With this new feature, users can now toggle between grid and list views when looking at shows. 

A new component <List /> in components/List is where the list view is generated. It is passed shows as props and for each show, generates a <Content /> component with the required information: name as the main header, comma-separated list of artists, scheduled start time, and ticket price. 

Also, another new component <ToggleView /> in components/ToggleView is what triggers the change between grid and list view. 