### PR TITLE
Issue #2: Page / 404 page for shows

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,15 @@
+import Layout from '@c/Layout'
+import styled from 'styled-components'
+
+const StyledH1 = styled.h1`
+  font-size: 50px;
+`
+
+export default function Error404() {
+  return (
+    <Layout>
+      <StyledH1> 404 </StyledH1>
+      <h3> Nothing to see here! </h3>
+    </Layout>
+  )
+}

--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -76,7 +76,15 @@ export async function getServerSideProps({ params }) {
   const { slug } = params
   const show = (await getShowBySlug(slug))
 
-  return {
-    props: { show },
+  if(show) {
+    return {
+      props: { show },
+    }
+  }
+  else {
+    // Throw a 404 if page does not exist 
+    return {
+      notFound: true,
+    }
   }
 }


### PR DESCRIPTION
If a user attempts to find a show which doesn't exist, an error message is displayed as opposed to the standard 404 page. 

[slug].js has been updated so that in the case a show does not exist, getServerSideProps() will return { notFound: true } which displays 404.js