### PR TITLE
Issue #7: Add Artist route

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -28,15 +28,15 @@ Sorting is a tricky one, and the solution for this issue depends. For the data s
 
 Sorting with GraphQL is not realistic here because these queries are executed at build time, therefore you cannot change GraphQL queries in the client. 
 
-- Issue #3: Add ability to sort shows 
+- Issue #3: Add ability to sort shows ✅
 
 
-- Issue #1: Create show list (not grid) view 
-- Issue #2: Page /404 for `shows`
+- Issue #1: Create show list (not grid) view ✅
+- Issue #2: Page /404 for `shows` ✅
 
 Priority 2: 
 
 - Issue #8: Shows uniform display on mobile 
 - Issue #9: Shows page is stupid-wide, not centered 
 - Issue #6: Add `spotifyUrl` to list of Artist links 
-- Issue #7: Add Artist Route 
+- Issue #7: Add Artist Route ✅

--- a/components/Link/index.js
+++ b/components/Link/index.js
@@ -1,9 +1,12 @@
 import { containsProtocol, prependHttps } from '@l/utils'
 
-export const Link = ({url, title}) => 
-  url && (
-    <a href={(containsProtocol(url)) ? url : prependHttps(url)} target="_blank"> 
-      {title} 
-    </a>
+export function Link({url, title}) {
+  return (
+    url && (
+      <a href={(containsProtocol(url)) ? url : prependHttps(url)} target="_blank"> 
+        {title} 
+      </a>
+    )
   )
+}
 

--- a/components/List/index.js
+++ b/components/List/index.js
@@ -7,12 +7,12 @@ function Content({ href, show }) {
     <Link href={href}>
       <a css={ListContent}>
         <ContentHeader>
-          <h2> { show.title } </h2>
+          <h2> {show.title} </h2>
           <h4> {show.artists.map(({ fullName }) => fullName).join(', ')} </h4>
         </ContentHeader>
         <ContentDescription>
-          <span> { formatDate(show.scheduledStartTime) } </span>
-          <span> $ { show.ticketPrice } </span>
+          <span> {formatDate(show.scheduledStartTime)} </span>
+          <span> $ {show.ticketPrice} </span>
         </ContentDescription>
       </a>
     </Link>

--- a/components/Sort/index.js
+++ b/components/Sort/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useContext } from 'react'
-import { FaAngleDown, FaSortAmountDown, FaSortAmountUp } from 'react-icons/fa'
+import { FaAngleDown } from 'react-icons/fa'
 import { ShowsContext } from '../../pages/shows'
 import { sortByProperty } from '@l/utils'
 import { Wrapper, StyledButton, StyledUl, StyledOption } from './Sort.css'
@@ -40,8 +40,8 @@ function SortOption({ type, icon, property }) {
 
   return (
     <StyledOption onClick={() => applySort(property)}> 
-      <span> { icon } </span>
-      <span> { type } </span>
+      <span> {icon} </span>
+      <span> {type} </span>
     </StyledOption>
   )
 }
@@ -57,7 +57,7 @@ export function Sort({ title, options }) {
   return (
     <Wrapper>
       <StyledButton onClick={() => setToggle(!toggle)}> 
-        <span> { title } </span>
+        <span> {title} </span>
         <FaAngleDown />
       </StyledButton>
 

--- a/components/ToggleView/index.js
+++ b/components/ToggleView/index.js
@@ -1,5 +1,4 @@
-import { useState } from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { BsFillGrid3X3GapFill, BsCardChecklist } from 'react-icons/bs'
 
 const Toggle = styled.div`

--- a/lib/graphcms.js
+++ b/lib/graphcms.js
@@ -44,6 +44,30 @@ export async function getAllShows() {
 }
 
 /**
+ * Retrieve a specific artist via GraphQL query
+ */
+export async function getArtistBySlug(slug) {
+  const data = await fetchAPI(
+    `query ($slug: String!) {
+      artist(where: {slug: $slug}) {
+        id
+        bio
+        fullName
+        facebookUrl
+        instagramUrl
+        youtubeUrl
+        webUrl
+        images {
+          url
+        }
+      }
+    }`,
+    { slug }
+  )
+  return data.artist
+}
+
+/**
  * Retrieve a specific show via GraphQL query
  */
 export async function getShowBySlug(slug) {

--- a/lib/graphcms.js
+++ b/lib/graphcms.js
@@ -55,7 +55,7 @@ export async function getArtistBySlug(slug) {
         fullName
         facebookUrl
         instagramUrl
-        youtubeUrl
+        youTubeUrl
         webUrl
         images {
           url
@@ -79,6 +79,7 @@ export async function getShowBySlug(slug) {
         ticketPrice
         artists {
           id
+          slug
           bio
           fullName
           facebookUrl

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -80,7 +80,7 @@ export function formatDate(
  * @param {string} url Could be an artist's web, facebook, instagram, etc. URL; should assume any of these links are incorrect
  * @returns {boolean}
  */
-export const containsProtocol = (url) => {
+export function containsProtocol(url) {
   if(!url) return false
 
   // The regex below tests if a url contains http(s), followed by ://, and subdomain/domain

--- a/pages/artist/[slug].js
+++ b/pages/artist/[slug].js
@@ -3,9 +3,6 @@ import styled from 'styled-components'
 import Layout from '@c/Layout'
 import { Link } from '@c/Link'
 import FlexyRow from '@c/FlexyRow'
-import { Title } from '@c/Title'
-import { getShowBySlug } from '@l/graphcms'
-import { formatUSD, formatDate } from '@l/utils'
 import { getArtistBySlug } from '@l/graphcms'
 
 export const Markdown = styled(ReactMarkdown)`

--- a/pages/artist/[slug].js
+++ b/pages/artist/[slug].js
@@ -1,0 +1,77 @@
+import ReactMarkdown from 'react-markdown'
+import styled from 'styled-components'
+import Layout from '@c/Layout'
+import { Link } from '@c/Link'
+import FlexyRow from '@c/FlexyRow'
+import { Title } from '@c/Title'
+import { getShowBySlug } from '@l/graphcms'
+import { formatUSD, formatDate } from '@l/utils'
+import { getArtistBySlug } from '@l/graphcms'
+
+export const Markdown = styled(ReactMarkdown)`
+  img {
+    width: 100%;
+    border-radius: 20px;
+    border: 4px solid currentColor;
+  }
+`
+
+export const ArtistName = styled.h2`
+  text-align: center;
+`
+
+export const ArtistPhoto = styled.div`
+  background-image: url(${(p) => p.imageUrl});
+  background-repeat: no-repeat;
+  background-size: cover;
+  width: 200px;
+  height: 200px;
+  border-radius: 100px;
+  border: 4px solid currentColor;
+  margin: 0 auto;
+`
+
+export const Portrait = ({ images = [] }) => {
+  if (images.length > 0) {
+    const img = images[0]
+    return (
+      <ArtistPhoto imageUrl={img.url} />
+    )
+  }
+  return null
+}
+
+export default function Artist({ artist }) {
+  return (
+    <Layout title={`${artist.fullName} / next-graphcms-shows`} maxWidth="900px" padding="0 2em">
+      <ArtistName> {artist.fullName} </ArtistName>
+
+      <Portrait images={artist.images} />
+
+      <FlexyRow justify="flex-start">
+        <Link url={artist.webUrl} title={"Website"} />
+        <Link url={artist.facebookUrl} title={"Facebook"} />
+        <Link url={artist.instagramUrl} title={"Instagram"} />
+        <Link url={artist.youTubeUrl} title={"YouTube"} />
+      </FlexyRow>
+
+      <Markdown source={artist.bio} />
+    </Layout>
+  )
+}
+
+export async function getServerSideProps({ params }) {
+  const { slug } = params
+  const artist = (await getArtistBySlug(slug))
+
+  if(artist) {
+    return {
+      props: { artist },
+    }
+  }
+  else {
+    return {
+      notFound: true,
+    }
+  }
+}

--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -23,8 +23,8 @@ export default function Shows({ show }) {
           return (
             <Link href={`/artist/${artist.slug}`} passHref key={artist.id}>
               <a>
-                <ArtistName> {artist.fullName} </ArtistName>
                 <Portrait images={artist.images} />
+                <ArtistName> {artist.fullName} </ArtistName>
               </a>
             </Link>
           )

--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -1,6 +1,6 @@
 import Layout from '@c/Layout'
-import { Link } from '@c/Link'
 import FlexyRow from '@c/FlexyRow'
+import Link from 'next/link'
 import { Title } from '@c/Title'
 import { getShowBySlug } from '@l/graphcms'
 import { formatUSD, formatDate } from '@l/utils'
@@ -18,22 +18,18 @@ export default function Shows({ show }) {
 
       <Markdown source={show.description} />
 
-      {show.artists.map(artist => (
-        <div key={artist.id}>
-          <ArtistName>{artist.fullName}</ArtistName>
-
-          <Portrait images={artist.images} />
-
-          <FlexyRow justify="flex-start">
-            <Link url={artist.webUrl} title={"Website"} />
-            <Link url={artist.facebookUrl} title={"Facebook"} />
-            <Link url={artist.instagramUrl} title={"Instagram"} />
-            <Link url={artist.youTubeUrl} title={"YouTube"} />
-          </FlexyRow>
-
-          <Markdown source={artist.bio} />
-        </div>
-      ))}
+      {show.artists.map((artist) => {
+        if(artist.slug) {
+          return (
+            <Link href={`/artist/${artist.slug}`} passHref key={artist.id}>
+              <a>
+                <ArtistName> {artist.fullName} </ArtistName>
+                <Portrait images={artist.images} />
+              </a>
+            </Link>
+          )
+        }
+      })}
     </Layout>
   )
 }

--- a/pages/show/[slug].js
+++ b/pages/show/[slug].js
@@ -1,44 +1,10 @@
-import ReactMarkdown from 'react-markdown'
-import styled from 'styled-components'
 import Layout from '@c/Layout'
 import { Link } from '@c/Link'
 import FlexyRow from '@c/FlexyRow'
 import { Title } from '@c/Title'
 import { getShowBySlug } from '@l/graphcms'
 import { formatUSD, formatDate } from '@l/utils'
-
-const Markdown = styled(ReactMarkdown)`
-  img {
-    width: 100%;
-    border-radius: 20px;
-    border: 4px solid currentColor;
-  }
-`
-
-const ArtistName = styled.h2`
-  text-align: center;
-`
-
-const ArtistPhoto = styled.div`
-  background-image: url(${(p) => p.imageUrl});
-  background-repeat: no-repeat;
-  background-size: cover;
-  width: 200px;
-  height: 200px;
-  border-radius: 100px;
-  border: 4px solid currentColor;
-  margin: 0 auto;
-`
-
-const Portrait = ({ images = [] }) => {
-  if (images.length > 0) {
-    const img = images[0]
-    return (
-      <ArtistPhoto imageUrl={img.url} />
-    )
-  }
-  return null
-}
+import { Markdown, ArtistName, Portrait } from '../artist/[slug]'
 
 export default function Shows({ show }) {
   return (

--- a/pages/shows.js
+++ b/pages/shows.js
@@ -28,10 +28,12 @@ export default function Shows({ data }) {
   return (
     <Layout title="next-graphcms-shows / Shows">
       <Title>Shows</Title>
+
       <ToggleView 
         grid={grid}
         setGrid={setGrid}
       />
+      
       {
         /**
          * To avoid prop drilling, pass [shows, setShows] into our Sort components with a context provider


### PR DESCRIPTION
Originally the project was designed so that all artist information was displayed within the shows.js page. The task of this issue was to extract the artist logic out from shows.js, and move it into its own page under pages/artist/[slug].js. 

In this PR there's a few changes in order to make this happen. The first is writing a new query in graphcms.js so that we can query artists by their slug, once the user attempts to use an artist dynamic route. The other modifications were mostly in pages/shows/[slug].js where the artist logic was removed. Lastly, the new artist page was created where all the artist details is rendered. 